### PR TITLE
Update logging

### DIFF
--- a/java/src/jmri/managers/configurexml/DefaultConditionalManagerXml.java
+++ b/java/src/jmri/managers/configurexml/DefaultConditionalManagerXml.java
@@ -219,7 +219,7 @@ public class DefaultConditionalManagerXml extends jmri.managers.configurexml.Abs
                 // Check for parent Logix
                 Logix x = tm.getParentLogix(sysName);
                 if (x == null) {
-                    log.debug("Conditional '{}' is an orphan -- no parent Logix", sysName);
+                    log.warn("Conditional '{}' has no parent Logix", sysName);
                     continue;
                 }
 
@@ -233,7 +233,7 @@ public class DefaultConditionalManagerXml extends jmri.managers.configurexml.Abs
                     }
                 }
                 if (!inIndex) {
-                    log.debug("Conditional '{}' is an orphan -- not in Logix index", sysName);
+                    log.debug("Conditional '{}' is not in the Logix index", sysName);
                     continue;
                 }
 


### PR DESCRIPTION
remove 'orphan' language, move to warn level for conditionals without Logix

This is the requested change from JMRI/JMRI#3481